### PR TITLE
添加"屏蔽表情包"选项

### DIFF
--- a/src/client/TelegramBotClient.ts
+++ b/src/client/TelegramBotClient.ts
@@ -1426,7 +1426,19 @@ export class TelegramBotClient extends BaseClient {
             return ctx.answerCbQuery(answerText)
         })
 
-        // 接受公众号消息
+        // 屏蔽表情包
+        bot.action(VariableType.SETTING_BLOCK_EMOTICON, ctx => {
+            const b = !this.forwardSetting.getVariable(VariableType.SETTING_BLOCK_EMOTICON)
+            const answerText = b ? this.t('common.open') : this.t('common.close')
+            this.forwardSetting.setVariable(VariableType.SETTING_BLOCK_EMOTICON, b)
+            // 修改后持成文件
+            this.forwardSetting.writeToFile()
+            // 点击后修改上面按钮
+            ctx.editMessageReplyMarkup(this.getSettingButton())
+            return ctx.answerCbQuery(answerText)
+        })
+
+        // 转发自己发的消息
         bot.action(VariableType.SETTING_FORWARD_SELF, ctx => {
             const b = !this.forwardSetting.getVariable(VariableType.SETTING_FORWARD_SELF)
             const answerText = b ? this.t('common.open') : this.t('common.close')
@@ -2583,6 +2595,7 @@ export class TelegramBotClient extends BaseClient {
                 [Markup.button.callback(this.t('command.setting.messageFallback', this.forwardSetting.getVariable(VariableType.SETTING_REPLY_SUCCESS) ? this.t('common.open') : this.t('common.close')), VariableType.SETTING_REPLY_SUCCESS),],
                 [Markup.button.callback(this.t('command.setting.autoSwitchContact', this.forwardSetting.getVariable(VariableType.SETTING_AUTO_SWITCH) ? this.t('common.open') : this.t('common.close')), VariableType.SETTING_AUTO_SWITCH),],
                 [Markup.button.callback(this.t('command.setting.receiveOfficial', this.forwardSetting.getVariable(VariableType.SETTING_ACCEPT_OFFICIAL_ACCOUNT) ? this.t('common.close') : this.t('common.open')), VariableType.SETTING_ACCEPT_OFFICIAL_ACCOUNT),],
+                [Markup.button.callback(this.t('command.setting.blockEmoticon', this.forwardSetting.getVariable(VariableType.SETTING_BLOCK_EMOTICON) ? this.t('common.open') : this.t('common.close')), VariableType.SETTING_BLOCK_EMOTICON),],
                 [Markup.button.callback(this.t('command.setting.forwardSelf', this.forwardSetting.getVariable(VariableType.SETTING_FORWARD_SELF) ? this.t('common.open') : this.t('common.close')), VariableType.SETTING_FORWARD_SELF),],
                 [Markup.button.callback(this.t('command.setting.mediaQualityCompression', this.forwardSetting.getVariable(VariableType.SETTING_COMPRESSION) ? this.t('common.open') : this.t('common.close')), VariableType.SETTING_COMPRESSION),],
                 [this.forwardSetting.getVariable(VariableType.SETTING_NOTION_MODE) === NotionMode.WHITE ?

--- a/src/client/WechatClient.ts
+++ b/src/client/WechatClient.ts
@@ -856,10 +856,13 @@ export class WeChatClient extends BaseClient {
                 })
                 // console.log('contact message', message)
                 break
+            case PUPPET.types.Message.Emoticon: // 处理表情消息的逻辑
+                if (this._tgClient.setting.getVariable(VariableType.SETTING_BLOCK_EMOTICON)) {
+                    break
+                }
             case PUPPET.types.Message.Attachment:
             case PUPPET.types.Message.Image:
             case PUPPET.types.Message.Audio:
-            case PUPPET.types.Message.Emoticon: // 处理表情消息的逻辑
             case PUPPET.types.Message.Video:
                 if (messageType === PUPPET.types.Message.Attachment && !message.payload?.filename) {
                     this.tgClient.sendQueueHelper.addMessageWithMsgId(uniqueId, {

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -107,6 +107,7 @@ const en = {
             messageFallback: 'Send successful feedback({0})',
             autoSwitchContact: 'Automatically switch contacts({0})',
             receiveOfficial: 'Receive official account messages({0})',
+            blockEmoticon: 'Block emoticon messages({0})',
             forwardSelf: 'Forward a message you sent on WeChat({0})',
             mediaQualityCompression: 'Media Quality Compression({0})',
             blackMode: 'Blacklist Mode',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -110,6 +110,7 @@ const zh = {
             messageFallback: '发送成功反馈({0})',
             autoSwitchContact: '自动切换联系人({0})',
             receiveOfficial: '接收公众号消息({0})',
+            blockEmoticon: '屏蔽表情包({0})',
             forwardSelf: '转发自己在微信发送的消息({0})',
             mediaQualityCompression: '媒体质量压缩({0})',
             blackMode: '黑名单模式',

--- a/src/model/Settings.ts
+++ b/src/model/Settings.ts
@@ -10,6 +10,7 @@ export class VariableContainer {
         [VariableType.SETTING_AUTO_SWITCH]: boolean,
         [VariableType.SETTING_CHAT_ID]: string,
         [VariableType.SETTING_ACCEPT_OFFICIAL_ACCOUNT]: boolean,
+        [VariableType.SETTING_BLOCK_EMOTICON]: boolean,
         [VariableType.SETTING_FORWARD_SELF]: boolean,
         [VariableType.SETTING_COMPRESSION]: boolean,
         [VariableType.SETTING_AUTO_GROUP]: boolean,
@@ -22,6 +23,7 @@ export class VariableContainer {
         [VariableType.SETTING_AUTO_SWITCH]: true,
         [VariableType.SETTING_CHAT_ID]: '',
         [VariableType.SETTING_ACCEPT_OFFICIAL_ACCOUNT]: false,
+        [VariableType.SETTING_BLOCK_EMOTICON]: false,
         [VariableType.SETTING_FORWARD_SELF]: false,
         [VariableType.SETTING_COMPRESSION]: false,
         [VariableType.SETTING_AUTO_GROUP]: false,
@@ -67,6 +69,7 @@ export class VariableContainer {
                 [VariableType.SETTING_FORWARD_SELF]: this.variables[VariableType.SETTING_FORWARD_SELF] ? this.variables[VariableType.SETTING_FORWARD_SELF] : false,
                 [VariableType.SETTING_COMPRESSION]: this.variables[VariableType.SETTING_COMPRESSION] ? this.variables[VariableType.SETTING_COMPRESSION] : false,
                 [VariableType.SETTING_ACCEPT_OFFICIAL_ACCOUNT]: this.variables[VariableType.SETTING_ACCEPT_OFFICIAL_ACCOUNT] ? this.variables[VariableType.SETTING_ACCEPT_OFFICIAL_ACCOUNT] : false,
+                [VariableType.SETTING_BLOCK_EMOTICON]: this.variables[VariableType.SETTING_BLOCK_EMOTICON] ? this.variables[VariableType.SETTING_BLOCK_EMOTICON] : false,
                 [VariableType.SETTING_AUTO_GROUP]: this.variables[VariableType.SETTING_AUTO_GROUP] ? this.variables[VariableType.SETTING_AUTO_GROUP] : false,
                 [VariableType.SETTING_LANGUAGE]: this.variables[VariableType.SETTING_LANGUAGE] ? this.variables[VariableType.SETTING_LANGUAGE] : 'zh',
             }
@@ -93,6 +96,8 @@ export enum VariableType {
     SETTING_CHAT_ID = 'chat_id',
     // 接受公众号消息
     SETTING_ACCEPT_OFFICIAL_ACCOUNT = 'Setting_Accept_Official_Account',
+    // 屏蔽表情包
+    SETTING_BLOCK_EMOTICON = 'SETTING_BLOCK_EMOTICON',
     // 转发自己发的消息
     SETTING_FORWARD_SELF = 'Setting_Forward_Self',
     // 媒体是否压缩
@@ -117,6 +122,7 @@ type VariableMap = {
     [VariableType.SETTING_AUTO_SWITCH]: boolean,
     [VariableType.SETTING_CHAT_ID]: string,
     [VariableType.SETTING_ACCEPT_OFFICIAL_ACCOUNT]: boolean,
+    [VariableType.SETTING_BLOCK_EMOTICON]: boolean,
     [VariableType.SETTING_FORWARD_SELF]: boolean,
     [VariableType.SETTING_COMPRESSION]: boolean,
     [VariableType.SETTING_AUTO_GROUP]: boolean,


### PR DESCRIPTION
添加了 `SETTING_BLOCK_EMOTICON` 设置选项，当选项设为开时，从微信接受到的所有表情包将不会转发到 TG。

ps. 我注意到 `SETTING_ACCEPT_OFFICIAL_ACCOUNT（接受公众号消息）` 实际上在代码逻辑上体现的是 `BLOCK` 的行为，可以考虑换个名字？

https://github.com/finalpi/wechat2tg/blob/6e37a9a8b3d74edf13f4373ac44575533eb0041e/src/client/WechatClient.ts#L677-L679